### PR TITLE
Move admin stuff into its own route

### DIFF
--- a/supabase-demo/app/src/app/admin/admin.component.html
+++ b/supabase-demo/app/src/app/admin/admin.component.html
@@ -1,0 +1,19 @@
+<nav mat-tab-nav-bar [tabPanel]="tabPanel">
+  <a
+    mat-tab-link
+    routerLink="/admin/open-sessions"
+    routerLinkActive
+    #rla="routerLinkActive"
+    [active]="rla.isActive"
+    >Live Sessions</a
+  >
+  <a
+    mat-tab-link
+    routerLink="/admin/manage-sessions"
+    routerLinkActive
+    #rla2="routerLinkActive"
+    [active]="rla2.isActive"
+    >All Sessions</a
+  >
+</nav>
+<mat-tab-nav-panel #tabPanel><router-outlet></router-outlet></mat-tab-nav-panel>

--- a/supabase-demo/app/src/app/admin/admin.component.spec.ts
+++ b/supabase-demo/app/src/app/admin/admin.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminComponent } from './admin.component';
+
+describe('AdminComponent', () => {
+  let component: AdminComponent;
+  let fixture: ComponentFixture<AdminComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AdminComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AdminComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/supabase-demo/app/src/app/admin/admin.component.ts
+++ b/supabase-demo/app/src/app/admin/admin.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-admin',
+  templateUrl: './admin.component.html',
+  styleUrls: ['./admin.component.css']
+})
+export class AdminComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/supabase-demo/app/src/app/app-routing.module.ts
+++ b/supabase-demo/app/src/app/app-routing.module.ts
@@ -1,12 +1,20 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AdminComponent } from './admin/admin.component';
 import { CreateSessionComponent } from './create-session/create-session.component';
 import { OpenSessionsComponent } from './open-sessions/open-sessions.component';
 
 const routes: Routes = [
-  { path: 'open-sessions', component: OpenSessionsComponent },
-  { path: 'manage-sessions', component: CreateSessionComponent },
-  { path: '', redirectTo: 'open-sessions', pathMatch: 'full' },
+  {
+    path: 'admin',
+    component: AdminComponent,
+    children: [
+      { path: 'open-sessions', component: OpenSessionsComponent },
+      { path: 'manage-sessions', component: CreateSessionComponent },
+      { path: '', redirectTo: 'manage-sessions', pathMatch: 'full' },
+    ],
+  },
+  { path: '', component: OpenSessionsComponent },
 ];
 
 @NgModule({

--- a/supabase-demo/app/src/app/app.component.html
+++ b/supabase-demo/app/src/app/app.component.html
@@ -3,22 +3,4 @@
   <div class="spacer"></div>
   <app-logout></app-logout>
 </mat-toolbar>
-<nav mat-tab-nav-bar [tabPanel]="tabPanel">
-  <a
-    mat-tab-link
-    routerLink="/open-sessions"
-    routerLinkActive
-    #rla="routerLinkActive"
-    [active]="rla.isActive"
-    >Open Sessions</a
-  >
-  <a
-    mat-tab-link
-    routerLink="/manage-sessions"
-    routerLinkActive
-    #rla2="routerLinkActive"
-    [active]="rla2.isActive"
-    >All Sessions</a
-  >
-</nav>
-<mat-tab-nav-panel #tabPanel><router-outlet></router-outlet></mat-tab-nav-panel>
+<router-outlet></router-outlet>

--- a/supabase-demo/app/src/app/app.component.ts
+++ b/supabase-demo/app/src/app/app.component.ts
@@ -1,8 +1,4 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { Select } from '@ngxs/store';
-import { map, Observable } from 'rxjs';
-import { AppState } from './_store/app.store';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-root',

--- a/supabase-demo/app/src/app/app.component.ts
+++ b/supabase-demo/app/src/app/app.component.ts
@@ -1,10 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Select } from '@ngxs/store';
+import { map, Observable } from 'rxjs';
+import { AppState } from './_store/app.store';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
-export class AppComponent {
-  title = 'app';
-}
+export class AppComponent {}

--- a/supabase-demo/app/src/app/app.module.ts
+++ b/supabase-demo/app/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { environment } from '../environments/environment';
 import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
+import { AdminComponent } from './admin/admin.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -40,6 +41,7 @@ import { MatIconModule } from '@angular/material/icon';
     AllSessionsComponent,
     CreateSessionDialogComponent,
     LoginFormComponent,
+    AdminComponent,
   ],
   imports: [
     CommonModule,

--- a/supabase-demo/app/src/app/create-session/create-session.component.ts
+++ b/supabase-demo/app/src/app/create-session/create-session.component.ts
@@ -8,7 +8,6 @@ import { CreateSessionDialogComponent } from './create-session-dialog/create-ses
   templateUrl: './create-session.component.html',
 })
 export class CreateSessionComponent {
-
   constructor(
     readonly sessionService: SessionService,
     private readonly dialog: MatDialog
@@ -19,5 +18,4 @@ export class CreateSessionComponent {
       minWidth: '250px',
     });
   }
-
 }

--- a/supabase-demo/app/src/app/login-form/login-form.component.html
+++ b/supabase-demo/app/src/app/login-form/login-form.component.html
@@ -4,13 +4,22 @@
     <form [formGroup]="form" (ngSubmit)="submit()">
       <p>
         <mat-form-field>
-          <input type="text" matInput placeholder="Email" formControlName="email">
+          <input
+            type="text"
+            matInput
+            placeholder="Email"
+            formControlName="email"
+          />
         </mat-form-field>
       </p>
-
       <p>
         <mat-form-field>
-          <input type="password" matInput placeholder="Password" formControlName="password">
+          <input
+            type="password"
+            matInput
+            placeholder="Password"
+            formControlName="password"
+          />
         </mat-form-field>
       </p>
 
@@ -21,7 +30,6 @@
       <div class="button">
         <button type="submit" mat-flat-button color="primary">Login</button>
       </div>
-
     </form>
   </mat-card-content>
 </mat-card>

--- a/supabase-demo/app/src/app/login-form/login-form.component.ts
+++ b/supabase-demo/app/src/app/login-form/login-form.component.ts
@@ -1,24 +1,24 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { SessionService } from '../session.service';
 
 class AuthorizationResult {
-  success:boolean
-  errorMessage: string | null
+  success: boolean;
+  errorMessage: string | null;
   constructor(success: boolean, errorMessage: string | null = null) {
-    this.success = success
-    this.errorMessage = errorMessage
+    this.success = success;
+    this.errorMessage = errorMessage;
   }
 }
 
 @Component({
   selector: 'app-login-form',
-  templateUrl: './login-form.component.html'
+  templateUrl: './login-form.component.html',
 })
-export class LoginFormComponent implements OnInit {
+export class LoginFormComponent {
   @Output() authenticationComplete = new EventEmitter();
   error: string | null = null;
-  
+
   form: FormGroup = new FormGroup({
     email: new FormControl('', [Validators.required]),
     password: new FormControl('', [Validators.required]),
@@ -26,25 +26,22 @@ export class LoginFormComponent implements OnInit {
 
   constructor(private readonly session: SessionService) {}
 
-  ngOnInit(): void {}
-
   async submit() {
     if (this.form.valid) {
-      const {email, password} = this.form.value
-      const {success, errorMessage} = await this.login(email, password)
+      const { email, password } = this.form.value;
+      const { success, errorMessage } = await this.login(email, password);
       if (success) {
-        this.error = ''
+        this.error = '';
         this.authenticationComplete.emit();
       } else {
-        this.error = errorMessage
+        this.error = errorMessage;
       }
     } else {
-      this.error = "Email and Password are required to login"
+      this.error = 'Email and Password are required to login';
     }
   }
 
   async login(email: string, password: string): Promise<AuthorizationResult> {
-    return await this.session.login(email, password)
+    return await this.session.login(email, password);
   }
-
 }

--- a/supabase-demo/app/src/app/open-sessions/open-sessions.component.html
+++ b/supabase-demo/app/src/app/open-sessions/open-sessions.component.html
@@ -1,5 +1,5 @@
 <mat-toolbar>
-  <span>Open Sessions</span>
+  <span>Live Sessions</span>
 </mat-toolbar>
 <div class="open-sessions">
   <mat-card

--- a/supabase-demo/app/src/app/session.service.ts
+++ b/supabase-demo/app/src/app/session.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient, User } from '@supabase/supabase-js';
 import { DateTime, Duration } from 'luxon';
 import { environment } from '../environments/environment';
 import { ApiGameSession, GameSession, NewSession } from './interfaces';
@@ -17,6 +17,7 @@ export class SessionService {
     );
   }
 
+  // no longer used?
   get openSessions() {
     return this.view
       .match({ status_id: 1 })
@@ -28,6 +29,7 @@ export class SessionService {
     return this.supabase.from<ApiGameSession>('v_game_sessions').select();
   }
 
+  // no longer used?
   get allSessions() {
     return this.supabase.from<GameSession>('game_session').select(`
         game_session_id,
@@ -47,7 +49,11 @@ export class SessionService {
   }
 
   get loggedIn() {
-    return !!this.supabase.auth.user()
+    return !!this.supabase.auth.user();
+  }
+
+  get loggedInUser(): User | null {
+    return this.supabase.auth.user();
   }
 
   create(gameSession: NewSession) {
@@ -86,25 +92,25 @@ export class SessionService {
   }
 
   async login(email: string, password: string): Promise<AuthorizationResult> {
-    const { error } = await this.supabase.auth.signIn({email, password})
+    const { error } = await this.supabase.auth.signIn({ email, password });
     if (error) {
-      return new AuthorizationResult(false, error.message)
+      return new AuthorizationResult(false, error.message);
     } else {
-      return new AuthorizationResult(true)
+      return new AuthorizationResult(true);
     }
   }
 
   async logout() {
     const { error } = await this.supabase.auth.signOut();
-    return error
+    return error;
   }
 }
 
 export class AuthorizationResult {
-  success:boolean
-  errorMessage: string | null
+  success: boolean;
+  errorMessage: string | null;
   constructor(success: boolean, errorMessage: string | null = null) {
-    this.success = success
-    this.errorMessage = errorMessage
+    this.success = success;
+    this.errorMessage = errorMessage;
   }
 }


### PR DESCRIPTION
- stick the nav tabs under admin
- redirect /admin to /admin/manage-sessions
- display the base path as just the open-sessions component, making a 'live' view
- rename "open" to "live" in ui

closes #9 